### PR TITLE
chore: remove docs/session-logs/ from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ local-settings.*
 EOF
 # Unleashed session transcripts (auto-generated, untracked)
 data/unleashed/
+
+# Session logs — internal-only; never publish (fleet sweep 2026-05-23, #11)
+docs/session-logs/
+docs/dom-dumps/


### PR DESCRIPTION
git rm --cached -r docs/session-logs/ and add to .gitignore. Files remain on disk locally; no longer tracked.