### PR TITLE
chore: scaffold CLAUDE.md to ADR 0219 lean template (stub catch-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,23 @@
-# CLAUDE.md - Iconoscope
+# CLAUDE.md - Iconoscope Project
 
-- **Repository:** `martymcenroe/Iconoscope`
+You are a team member on the Iconoscope project, not a tool.
+
+## Project Identifiers
+
+- **Repository:** `martymcenroe/iconoscope`
+- **Project Root (Windows):** `C:\Users\mcwiz\Projects\Iconoscope`
+- **Project Root (Unix):** `/c/Users/mcwiz/Projects/Iconoscope`
+- **Worktree Pattern:** `Iconoscope-{IssueID}` (e.g., `Iconoscope-45`)
+
+## Project-Specific Context
+
+_TODO: Add tech stack, architecture, file map, project-type-specific notes,
+and any workflow overrides specific to this project. The universal
+CLAUDE.md (auto-loaded by Claude Code's parent-directory traversal) covers
+fleet-wide rules -- this file only adds what's true for THIS repo
+specifically. Restating universal content here creates drift on every
+universal-CLAUDE.md edit (ADR 0219)._
+
+## Workflow Overrides
+
+_None yet. If this project needs to override any universal CLAUDE.md rule (e.g., a custom merge tool, a special test convention), document the override here with explicit language ("override") per ADR 0219._


### PR DESCRIPTION
## Summary

Expands Iconoscope's 3-line CLAUDE.md to the lean per-repo template per AssemblyZero ADR 0219. Resolves lint M8 (stub).

## What changed

- Added scaffolder-parity Project Identifiers + preamble + Workflow Overrides footer
- No project-type signal detected -- uses the minimal stub from new_repo_setup.py with TODO block

## Test plan

- [x] ``poetry run python tools/lint_per_repo_claude_md.py`` reports ``Iconoscope-stub-catchup: PASS``, 23 lines, 0 findings

No-Issue: scaffolder catch-up -- applies AssemblyZero ADR 0219 lean template per #1290 lint sweep to a stub repo. Operator-authorized fleet sweep 2026-05-26.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)