### PR TITLE
chore: remove obsolete handshake block from GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,15 +15,6 @@ That file contains core rules that apply to ALL projects and ALL agents:
 
 ## 1. Session Initialization (The Handshake)
 
-**CRITICAL:** When a session begins:
-1. **Analyze:** Silently parse the provided `git status` or issue context.
-2. **Halt & Ask:** Your **FIRST** output must be exactly:
-   > "ACK. State determination complete. Please identify my model version."
-3. **Wait:** Do not proceed until the user replies (e.g., "3.0 Pro").
-4. **Update Identity:** Incorporate the version into your Metadata Tag for all future turns.
-
----
-
 ## 2. Execution Rules
 
 - **Authority:** `AgentOS:standards/0002-coding-standards` is the law for Git workflows.


### PR DESCRIPTION
## Summary

Removes the 9-line "ACK. State determination complete. Please identify my model version." handshake instruction from ``GEMINI.md`` section 1.

## Why

The handshake was an early Gemini-session protocol convention that's no longer relevant. Relates to the pending Gemini CLI → Antigravity CLI switch in mid-June (AssemblyZero #1335 spike). Applied uniformly across all 7 dormant repos in the fleet today.

## Test plan

- [x] Single block deletion in GEMINI.md (lines 18-26 of the prior file)
- [x] Section 1 header retained (empty section), section 2 header unchanged
- [x] No code changes; no tests affected

No-Issue: fleet-wide GEMINI.md handshake-block cleanup. Operator-authorized fleet sweep 2026-05-27. Uniform 9-line deletion across 7 dormant repos (Agora, GlucoPulse, Iconoscope, Orpheus, athleet.dev, data-harvest, maintenance).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)