### PR TITLE
chore(GEMINI.md): remove blocking session-handshake/ACK

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,8 +13,6 @@ That file contains core rules that apply to ALL projects and ALL agents:
 
 ---
 
-## 1. Session Initialization (The Handshake)
-
 ## 2. Execution Rules
 
 - **Authority:** `AgentOS:standards/0002-coding-standards` is the law for Git workflows.


### PR DESCRIPTION
Removes the `## Session Initialization (The Handshake)` section from GEMINI.md. It instructs the agent to emit an `ACK` and HALT until the user replies, which blocks the Antigravity CLI (`agy`) on auto-load. Operator-confirmed by direct test.

No-Issue: remove the blocking Gemini session-handshake/ACK from GEMINI.md -- it halts Antigravity CLI (agy) on auto-load. Operator-confirmed by direct test that agy prompts the ACK in repos that still carry it. Fleet consistency cleanup.